### PR TITLE
handling validation for book_id is not a number

### DIFF
--- a/public/js/Add_Transaction.js
+++ b/public/js/Add_Transaction.js
@@ -9,7 +9,7 @@ function displayMessage(message, type) {
         messageElement.style.color = "green"; // Success message color
     } else if (type === "error") {
         messageElement.style.color = "red"; // Error message color
-    }
+    } 
 
     // Hide the message after a few seconds
     setTimeout(() => {
@@ -29,6 +29,11 @@ function addTransaction() {
         return;
     }
 
+    if(isNaN(book_id)){
+        displayMessage("book_id must be in number")
+        return;
+    }
+    
     const transactionData = { book_id, borrower_name, borrowDate, returnDate };
 
     // Send transaction data to server


### PR DESCRIPTION
The book_id field previously lacked proper validation, leading to potential issues if non-numeric values were entered or if IDs were referenced with this pull rerequest it ensure that it is properly validated 